### PR TITLE
Added .DS_Store and thumbs.db to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 JabFox.sublime-workspace
 node_modules
 web-ext-artifacts
+
+# Directory Cache files
+.DS_Store
+thumbs.db


### PR DESCRIPTION
## Description

`.DS_Store` is a MacOS directory cache file and `thumbs.db` is a windows directory cache file. Sometimes Mac/Windows users accidentally push these files to the repo which may interfere with other Mac/Windows users.